### PR TITLE
Add locality to Hint Rewrites.

### DIFF
--- a/src/Array.v
+++ b/src/Array.v
@@ -8,6 +8,7 @@ From Classes Require Import Default.
 Set Implicit Arguments.
 (* for compatibility with coq master *)
 Set Warnings "-undeclared-scope".
+Set Warnings "-unsupported-attributes".
 
 Set Default Proof Using "Type".
 
@@ -30,7 +31,7 @@ Section Array.
   Hint Extern 3 (_ >= _) => lia : core.
 
   (* there's no way to create a rewriting base other than adding a hint *)
-  Hint Rewrite (@eq_refl False) using fail : solve_rewrite.
+  #[local] Hint Rewrite (@eq_refl False) using fail : solve_rewrite.
 
   Ltac simplify :=
     autorewrite with solve_rewrite in *.
@@ -262,9 +263,9 @@ Section Array.
     - destruct l; simpl; auto.
   Qed.
 
-  Hint Rewrite firstn_nil skipn_nil : solve_rewrite.
-  Hint Rewrite firstn_length_le using (solve_lengths) : length.
-  Hint Rewrite skipn_length : length.
+  #[local] Hint Rewrite firstn_nil skipn_nil : solve_rewrite.
+  #[local] Hint Rewrite firstn_length_le using (solve_lengths) : length.
+  #[local] Hint Rewrite skipn_length : length.
 
   Theorem subslice_nil n m :
     subslice nil n m = @nil A.
@@ -321,10 +322,10 @@ Section Array.
     induct l.
   Qed.
 
-  Hint Rewrite index_oob using lia : array.
-  Hint Rewrite index_firstn using lia : array.
-  Hint Rewrite index_firstn_oob using lia : array.
-  Hint Rewrite index_skipn using lia : array.
+  #[local] Hint Rewrite index_oob using lia : array.
+  #[local] Hint Rewrite index_firstn using lia : array.
+  #[local] Hint Rewrite index_firstn_oob using lia : array.
+  #[local] Hint Rewrite index_skipn using lia : array.
 
   Theorem subslice_index_ok l : forall n m i,
       i < m ->
@@ -499,26 +500,26 @@ Local Ltac solve_bounds :=
 Local Ltac solve_lengths :=
   autorewrite with length; solve_bounds.
 
-Hint Rewrite length_assign : length.
-Hint Rewrite length_subslice_oob using solve_lengths : length.
+#[export] Hint Rewrite length_assign : length.
+#[export] Hint Rewrite length_subslice_oob using solve_lengths : length.
 
-Hint Rewrite index_oob using solve_lengths : array.
-Hint Rewrite index_assign_eq using solve_lengths : array.
-Hint Rewrite index_assign_ne using solve_bounds : array.
+#[export] Hint Rewrite index_oob using solve_lengths : array.
+#[export] Hint Rewrite index_assign_eq using solve_lengths : array.
+#[export] Hint Rewrite index_assign_ne using solve_bounds : array.
 
-Hint Rewrite sel_assign_eq using solve_lengths : array.
-Hint Rewrite sel_assign_ne using solve_bounds : array.
-Hint Rewrite assign_oob using solve_lengths : array.
-Hint Rewrite assign_assign_eq : array.
+#[export] Hint Rewrite sel_assign_eq using solve_lengths : array.
+#[export] Hint Rewrite sel_assign_ne using solve_bounds : array.
+#[export] Hint Rewrite assign_oob using solve_lengths : array.
+#[export] Hint Rewrite assign_assign_eq : array.
 
-Hint Rewrite index_app_fst using solve_lengths : array.
-Hint Rewrite index_app_snd using solve_lengths : array.
-Hint Rewrite index_app_snd_off : array.
+#[export] Hint Rewrite index_app_fst using solve_lengths : array.
+#[export] Hint Rewrite index_app_snd using solve_lengths : array.
+#[export] Hint Rewrite index_app_snd_off : array.
 
-Hint Rewrite subslice_index_ok using solve_bounds : array.
-Hint Rewrite subslice_index_oob using solve_bounds : array.
-Hint Rewrite subslice_index_oob_l using solve_lengths : array.
-Hint Rewrite subslice_sel_ok using solve_bounds : array.
-Hint Rewrite subslice_select_array using solve_lengths : array.
+#[export] Hint Rewrite subslice_index_ok using solve_bounds : array.
+#[export] Hint Rewrite subslice_index_oob using solve_bounds : array.
+#[export] Hint Rewrite subslice_index_oob_l using solve_lengths : array.
+#[export] Hint Rewrite subslice_sel_ok using solve_bounds : array.
+#[export] Hint Rewrite subslice_select_array using solve_lengths : array.
 
 Ltac array := autorewrite with length array; auto.

--- a/src/MultiAssign.v
+++ b/src/MultiAssign.v
@@ -9,6 +9,8 @@ From Classes Require Import EqualDec.
 Import EqualDecNotation.
 
 Set Implicit Arguments.
+(* for compatibility with coq master *)
+Set Warnings "-unsupported-attributes".
 
 Section Array.
   Context (A:Type).
@@ -101,7 +103,7 @@ Section Array.
 
 End Array.
 
-Hint Rewrite length_massign : length.
-Hint Rewrite massign_not_in using solve [ auto; congruence ] : array.
-Hint Rewrite massign_snoc : array.
+#[global] Hint Rewrite length_massign : length.
+#[global] Hint Rewrite massign_not_in using solve [ auto; congruence ] : array.
+#[global] Hint Rewrite massign_snoc : array.
 (* massign_in requires erewriting *)


### PR DESCRIPTION
This time we do it more carefully by deactivating unknown attributes in order to keep compatibility with Coq 8.13.
