### PR TITLE
Fix deprecation warnings and update CI

### DIFF
--- a/.github/workflows/coq-action.yml
+++ b/.github/workflows/coq-action.yml
@@ -18,13 +18,10 @@ jobs:
       matrix:
         image:
           - "coqorg/coq:dev"
-          - "coqorg/coq:8.14"
-          - "coqorg/coq:8.13"
-          - "coqorg/coq:8.12"
-          - "coqorg/coq:8.11"
+          - "coqorg/coq:latest"
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
         with:
           submodules: true
       - uses: coq-community/docker-coq-action@v1
@@ -39,14 +36,10 @@ jobs:
             endGroup
           script: |
             startGroup "Build project"
-              make -j2 -k
+              make -j4 -k
             endGroup
           after_script:
           uninstall:
       - name: Revert permissions
-        # to avoid a warning at cleanup time
         if: ${{ always() }}
         run: sudo chown -R 1001:116 .
-# See also:
-# https://github.com/coq-community/docker-coq-action#readme
-# https://github.com/erikmd/docker-coq-github-action-demo

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 *.glob
 .*.aux
 .coqdeps.d
+_CoqProject
 .lia.cache

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ TEST_VFILES := $(shell find -L 'src' -name "*Tests.v")
 PROJ_VFILES := $(shell find -L 'src' -name "*.v")
 VFILES := $(filter-out $(TEST_VFILES),$(PROJ_VFILES))
 
-COQPROJECT_ARGS := $(shell sed -E -e '/^\#/d' -e 's/-arg ([^ ]*)/\1/g' _CoqProject)
+COQPROJECT_ARGS := $(shell sed -E -e '/^\#/d' -e 's/-arg ([^ ]*)/\1/g' _RocqProject)
 COQARGS := $(COQPROJECT_ARGS)
 
 default: $(VFILES:.v=.vo)
@@ -12,15 +12,15 @@ test: $(TEST_VFILES:.v=.vo) $(VFILES:.v=.vo)
 
 .coqdeps.d: $(ALL_VFILES)
 	@echo "COQDEP $@"
-	@coqdep -f _CoqProject $(ALL_VFILES) > $@
+	@rocq dep -f _RocqProject $(ALL_VFILES) > $@
 
 ifneq ($(MAKECMDGOALS), clean)
 -include .coqdeps.d
 endif
 
-%.vo: %.v _CoqProject
+%.vo: %.v _RocqProject
 	@echo "COQC $<"
-	@coqc $(COQARGS) $< -o $@
+	@rocq compile $(COQARGS) $< -o $@
 
 clean:
 	@echo "CLEAN vo glob aux"

--- a/_CoqProject
+++ b/_CoqProject
@@ -1,5 +1,0 @@
--Q src Array
--Q vendor/classes/src Classes
--arg -w -arg +all,-disj-pattern-notation
-# for backwards compatibility
--arg -w -arg -deprecated-hint-rewrite-without-locality

--- a/_RocqProject
+++ b/_RocqProject
@@ -1,0 +1,3 @@
+-Q src Array
+-Q vendor/classes/src Classes
+-arg -w -arg +deprecated-since-8.8,+deprecated-since-8.17,+deprecated-since-8.20,+deprecated-since-9.0,-deprecated-transitive-library-file-since-9.0

--- a/src/Array.v
+++ b/src/Array.v
@@ -1,6 +1,6 @@
-From Coq Require Import List.
-From Coq Require Import Lia.
-From Coq Require Import PeanoNat.
+From Stdlib Require Import List.
+From Stdlib Require Import Lia.
+From Stdlib Require Import PeanoNat.
 Import Compare_dec.
 
 From Classes Require Import Default.
@@ -12,7 +12,7 @@ Set Warnings "-unsupported-attributes".
 
 Set Default Proof Using "Type".
 
-Section Array.
+Section ArrayDefs.
   Context (A:Type).
   Context {def: Default A}.
   Notation list := (list A).
@@ -278,7 +278,7 @@ Section Array.
     length (subslice l n m) = Nat.min m (length l - n).
   Proof.
     unfold subslice.
-    rewrite firstn_length.
+    rewrite length_firstn.
     rewrite skipn_length.
     auto.
   Qed.
@@ -482,7 +482,7 @@ Section Array.
     lia.
   Qed.
 
-End Array.
+End ArrayDefs.
 
 Module ArrayNotations.
   (* Declare Scope array_scope. *)

--- a/src/MultiAssign.v
+++ b/src/MultiAssign.v
@@ -1,8 +1,8 @@
 From Array Require Import Array.
 
-From Coq Require Import List.
-From Coq Require Import Lia.
-From Coq Require Import PeanoNat.
+From Stdlib Require Import List.
+From Stdlib Require Import Lia.
+From Stdlib Require Import PeanoNat.
 Import Compare_dec.
 
 From Classes Require Import EqualDec.


### PR DESCRIPTION
## Summary
- Replace `From Coq` with `From Stdlib` across all source files
- Fix `NArith.NArith`/`ZArith.ZArith`, bare `Require` of Stdlib modules
- Rename `Section Array` to `Section ArrayDefs` (masking-absolute-name)
- Replace `firstn_length` with `length_firstn`
- Switch `_CoqProject` to `_RocqProject`, use `rocq compile`/`rocq dep`
- Add deprecation warning-as-error flags
- Update CI: `coq_version` with dev/latest, actions/checkout v6, -j4

## Test plan
- [ ] CI passes on dev and latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)